### PR TITLE
Fix username propagation for status plugin

### DIFF
--- a/plugins/user-status/server.js
+++ b/plugins/user-status/server.js
@@ -33,10 +33,19 @@ class UserStatusPlugin {
       
       // Broadcast to all users in the same room
       const rooms = Array.from(socket.rooms).filter(r => r !== socket.id);
+      // Determine username from socket or activeUsers map
+      let username = socket.username;
+      if (!username && this.io.activeUsers) {
+        const user = this.io.activeUsers.get(socket.id);
+        if (user && user.username) {
+          username = user.username;
+        }
+      }
+
       rooms.forEach(room => {
         this.io.to(room).emit('status:update', {
           userId: socket.id,
-          username: socket.username || 'Unknown',
+          username: username || 'Unknown',
           status: newStatus
         });
       });
@@ -47,8 +56,15 @@ class UserStatusPlugin {
     const statuses = {};
     for (const [socketId, status] of this.userStatuses) {
       const socket = this.io.sockets.sockets.get(socketId);
-      if (socket && socket.username) {
-        statuses[socket.username] = status;
+      let username = socket && socket.username;
+      if (!username && this.io.activeUsers) {
+        const user = this.io.activeUsers.get(socketId);
+        if (user && user.username) {
+          username = user.username;
+        }
+      }
+      if (username) {
+        statuses[username] = status;
       }
     }
     return statuses;

--- a/server.js
+++ b/server.js
@@ -524,6 +524,8 @@ const io = new Server(server, {
   pingTimeout: 60000,
   pingInterval: 25000
 });
+// Expose active users map for plugins
+io.activeUsers = activeUsers;
 
 // Serve static assets
 app.use(express.static(path.join(__dirname, '/')));
@@ -824,6 +826,9 @@ io.on('connection', async (socket) => {
       socket.emit('auth error', 'Username already taken in this room');
       return;
     }
+
+    // Store username on the socket for plugins
+    socket.username = sanitizedName;
 
     let isAdmin = false;
     if (password === USER_PASSWORD) {


### PR DESCRIPTION
## Summary
- expose `activeUsers` on `io`
- persist sanitized username on sockets when users join rooms
- allow User Status plugin to fetch usernames from `io.activeUsers`

## Testing
- `node server.js` *(launched in background)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_686e99a7108483299f6d1fda5d59f9c8