### PR TITLE
Fix static middleware in plugin loader

### DIFF
--- a/plugin-loader.js
+++ b/plugin-loader.js
@@ -1,6 +1,7 @@
 // Server-side Plugin Loader
 const fs = require('fs').promises;
 const path = require('path');
+const express = require('express');
 
 class ServerPluginLoader {
   constructor(io, app) {
@@ -76,8 +77,8 @@ class ServerPluginLoader {
       
       // Set up static routes for client files
       if (config.clientScript) {
-        this.app.use(`/js/plugins/${pluginId}`, this.app.express.static(pluginPath));
-        this.app.use(`/css/plugins/${pluginId}`, this.app.express.static(pluginPath));
+        this.app.use(`/js/plugins/${pluginId}`, express.static(pluginPath));
+        this.app.use(`/css/plugins/${pluginId}`, express.static(pluginPath));
       }
       
     } catch (err) {


### PR DESCRIPTION
## Summary
- import Express directly in `plugin-loader.js`
- use `express.static` when mounting plugin assets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e9d77133c8329a110fe4ec6438712