### PR TITLE
Implement direct sell logic and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon server.js",
     "init-db": "node -e \"const sqlite3 = require('sqlite3').verbose(); const db = new sqlite3.Database('./database/pocketanimals.db'); console.log('Database initialized'); db.close();\"",
     "backup-db": "cp ./database/pocketanimals.db ./database/backup-$(date +%Y%m%d-%H%M%S).db",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [
     "chat",

--- a/test/sell.test.js
+++ b/test/sell.test.js
@@ -1,0 +1,36 @@
+process.env.NODE_ENV = 'test';
+const test = require('node:test');
+const assert = require('assert');
+const {
+  initDatabase,
+  createUser,
+  addAnimalToUser,
+  getUserById,
+  getUserAnimals,
+  performSell
+} = require('../server');
+
+const dog = {
+  name: '🐶 Dog',
+  emoji: '🐶',
+  rarity: 'common',
+  level: 1,
+  str: 8,
+  mag: 4,
+  pr: 6,
+  mr: 5,
+  hp: 25,
+  wp: 10
+};
+
+test('performSell sells animals via command', async () => {
+  await initDatabase();
+  const userId = await createUser('tester', 'pass');
+  await addAnimalToUser(userId, dog);
+  await addAnimalToUser(userId, dog);
+  const result = await performSell(userId, '🐶 Dog', 2);
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.newCowoncy, 106);
+  const remaining = await getUserAnimals(userId);
+  assert.strictEqual(remaining.length, 0);
+});


### PR DESCRIPTION
## Summary
- add `performSell` helper with selling logic
- reuse `performSell` in `/sell` command and `game sell animal` handler
- export helpers and guard server startup for testing
- add a unit test for selling animals
- set `npm test` to use the built-in Node test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb886bb048329b9019dad3e61340b