### PR TITLE
Fix npm test by ensuring dependencies installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "pretest": "npm install",
     "init-db": "node -e \"const sqlite3 = require('sqlite3').verbose(); const db = new sqlite3.Database('./database/pocketanimals.db'); console.log('Database initialized'); db.close();\"",
     "backup-db": "cp ./database/pocketanimals.db ./database/backup-$(date +%Y%m%d-%H%M%S).db",
     "test": "node --test"


### PR DESCRIPTION
## Summary
- add a `pretest` script so running `npm test` installs dependencies automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f5a8fe5088329afd455a363095508