### PR TITLE
Fix room switching for PocketAnimals

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,6 +277,13 @@ document.addEventListener('DOMContentLoaded', () => {
     unreadRooms.delete(newRoom);
     isInGameRoom = newRoom === 'pocketanimals';
 
+    // Inform server about the room change
+    socket.emit('join room', {
+      name: user.name,
+      room: newRoom,
+      password: passInput.value
+    });
+
     // Update UI based on room
     gamePanel.classList.toggle('active', isInGameRoom);
     gameQuickActions.classList.toggle('active', isInGameRoom);


### PR DESCRIPTION
## Summary
- ensure client notifies the server when switching rooms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68714c364e448329a7b6bf2f8625493b