### PR TITLE
Add server restart on webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This repository ships with a `user-status` plugin located in `plugins/user-statu
 The server can automatically pull the latest code when changes are pushed to the
 repository. Set the `GITHUB_WEBHOOK_SECRET` environment variable and create a
 GitHub webhook that sends **push** events to `/git-webhook` on your deployed
-server. When a valid webhook is received, the server executes `git pull` to
-update the codebase.
+server. When a valid webhook is received, the server executes `git pull`
+followed by `npm install` to update dependencies, then restarts itself so
+the new code is immediately active.
 
 

--- a/server.js
+++ b/server.js
@@ -629,7 +629,18 @@ app.post('/git-webhook', (req, res) => {
       return res.status(500).send('Pull failed');
     }
     console.log('Git pull output:', stdout);
-    res.send('Repository updated');
+    exec('npm install --omit=dev', (instErr, instStdout, instStderr) => {
+      if (instErr) {
+        console.error('npm install failed:', instStderr);
+      } else {
+        console.log('npm install output:', instStdout);
+      }
+      res.send('Repository updated, restarting server');
+      res.on('finish', () => {
+        console.log('Restarting server to apply updates');
+        process.exit(0);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- update webhook to install deps and restart server when code updates
- document automatic server restart in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68716d0af3048329ad9464092f2305d5