### PR TITLE
Add optional HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Start the application with:
 npm start
 ```
 
-The server listens on port `3000` by default. Once running, open your browser and navigate to <http://localhost:3000> to access the chat UI and PocketAnimals game.
+By default the server attempts to start over **HTTPS** on port `443` if SSL certificates are available. Provide the `SSL_KEY_PATH` and `SSL_CERT_PATH` environment variables (or place `ssl/key.pem` and `ssl/cert.pem` in the project root) to enable HTTPS.
+
+If certificates are not found the server falls back to HTTP on port `3000`.
+Once running, open your browser and navigate to the appropriate URL (e.g. <https://localhost> when using HTTPS) to access the chat UI and PocketAnimals game.
 
 ## Plugin System
 


### PR DESCRIPTION
## Summary
- configure server.js to use HTTPS when certificates are available
- start HTTPS on port 443 by default and fall back to HTTP/3000
- adjust console output and shutdown messages
- document HTTPS setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687691c8d7ec83298e000c9580ee6531